### PR TITLE
Fix trpc errors deserialization

### DIFF
--- a/src/link/internal/base.ts
+++ b/src/link/internal/base.ts
@@ -31,8 +31,7 @@ export const createBaseLink = <TRouter extends AnyRouter>(
             if (id !== trpc.id) return;
 
             if ('error' in trpc) {
-              const error = trpc.error;
-              observer.error(TRPCClientError.from({ ...trpc, error }));
+              observer.error(TRPCClientError.from(trpc));
               return;
             }
 

--- a/src/link/internal/base.ts
+++ b/src/link/internal/base.ts
@@ -31,7 +31,7 @@ export const createBaseLink = <TRouter extends AnyRouter>(
             if (id !== trpc.id) return;
 
             if ('error' in trpc) {
-              const error = runtime.transformer.deserialize(trpc.error);
+              const error = trpc.error;
               observer.error(TRPCClientError.from({ ...trpc, error }));
               return;
             }


### PR DESCRIPTION
tRPC is not using transformer.serialize for errors, so we don't need to deserialize them. We rather have an `errorFormatter` for this purpose.

This is failing when using `superjson` as transformer.